### PR TITLE
Fix import

### DIFF
--- a/onnx_mxnet/__init__.py
+++ b/onnx_mxnet/__init__.py
@@ -9,7 +9,7 @@
 # permissions and limitations under the License.
 
 # coding: utf-8
-from import_onnx import GraphProto
+from .import_onnx import GraphProto
 import onnx
 
 def import_model(model_file):


### PR DESCRIPTION
A missing dot causes an import error like this:

```
$ python -c 'import onnx_mxnet'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/ubuntu/.pyenv/versions/anaconda3-5.0.0/lib/python3.6/site-packages/onnx_mxnet/__init__.py", line 12, in <module>
    from import_onnx import GraphProto
ModuleNotFoundError: No module named 'import_onnx'
```

This PR fixes this problem, so that the issue #2 may be solved.