### PR TITLE
Fix for Deconvolution filter size.

### DIFF
--- a/onnx_mxnet/import_onnx.py
+++ b/onnx_mxnet/import_onnx.py
@@ -311,9 +311,16 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
         else:
             wshape = self._params[weight_name].shape
             assert len(wshape) >= 2, "Weights shape is invalid: {}".format(wshape)
-            channels = wshape[0]
+
             if op in [mx.sym.FullyConnected]:
-                attrs['num_hidden'] = channels
+                attrs['num_hidden'] = wshape[0]
             else:
-                attrs['num_filter'] = channels
+                if op == mx.sym.Convolution:
+                    # Weight shape for Conv and FC: (M x C x kH x kW) : M is number of
+                    # feature maps/hidden  and C is number of channels
+                    attrs['num_filter'] = wshape[0]
+                elif op == mx.sym.Deconvolution:
+                    # Weight shape for DeConv : (C x M x kH x kW) : M is number of
+                    # feature maps/filters and C is number of channels
+                    attrs['num_filter'] = wshape[1]
         return attrs

--- a/onnx_mxnet/tests/test_layers.py
+++ b/onnx_mxnet/tests/test_layers.py
@@ -325,6 +325,32 @@ class TestLayers(unittest.TestCase):
         output = mxnet_backend.run_node(node, [input1])[0]
         npt.assert_almost_equal(output, input1)
 
+    def test_deconv(self):
+        """ Test Deconvolution operator"""
+        input1 = np.arange(9).reshape((1, 1, 3, 3))
+        weight = np.ones(shape=(1, 3, 3, 3))
+
+        result = np.array([[[[0., 1., 3., 3., 2.],
+                             [3., 8., 15., 12., 7.],
+                             [9., 21., 36., 27., 15.],
+                             [9., 20., 33., 24., 13.],
+                             [6., 13., 21., 15., 8.]],
+                            [[0., 1., 3., 3., 2.],
+                             [3., 8., 15., 12., 7.],
+                             [9., 21., 36., 27., 15.],
+                             [9., 20., 33., 24., 13.],
+                             [6., 13., 21., 15., 8.]],
+                            [[0., 1., 3., 3., 2.],
+                             [3., 8., 15., 12., 7.],
+                             [9., 21., 36., 27., 15.],
+                             [9., 20., 33., 24., 13.],
+                             [6., 13., 21., 15., 8.]]]])
+
+        node_def = helper.make_node("ConvTranspose", ["input1", "W"], ["Y"], kernel_shape=(3, 3))
+        output = mxnet_backend.run_node(node_def, [input1, weight])[0]
+        npt.assert_almost_equal(output, result)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Description:
Weight shape for DeConv : (C x M x kH x kW) : M is number of feature maps/filters and C is number of channels
picking shape[1] ('M') for num of filters , currently incorrectly using shape[0] ('C')

Fixes Issue reported here:
https://github.com/onnx/onnx-mxnet/issues/11

@Roshrini @lupesko  @nswamy @anirudhacharya 
