### PR TITLE
Fix for Reduce operators

### DIFF
--- a/onnx_mxnet/backend.py
+++ b/onnx_mxnet/backend.py
@@ -48,7 +48,8 @@ class MXNetBackend(Backend):
         sym = graph.run_node(node)
         data_names = [i for i in node.input]
         data_shapes = []
-        reduce_op_types = set(['ReduceMin', 'ReduceMax', 'ReduceMean', 'ReduceProd', 'ReduceSum', 'Slice', 'Pad'])
+        reduce_op_types = set(['ReduceMin', 'ReduceMax', 'ReduceMean',
+                               'ReduceProd', 'ReduceSum', 'Slice', 'Pad'])
 
         # Adding extra dimension of batch_size 1 if the batch_size is different for multiple inputs.
         for idx, input_name in enumerate(data_names):

--- a/onnx_mxnet/import_helper.py
+++ b/onnx_mxnet/import_helper.py
@@ -196,11 +196,11 @@ _convert_map = {
     'Flatten'       : Renamer('Flatten'),
     'LRN'           : AttrCvt('LRN', {'bias': 'knorm', 'size' : 'nsize'}),
     # defs/reduction
-    'ReduceMax'     : AttrCvt('max', {'axes', 'axis'}),
-    'ReduceMin'     : AttrCvt('min', {'axes', 'axis'}),
-    'ReduceSum'     : AttrCvt('sum', {'axes', 'axis'}),
-    'ReduceMean'    : AttrCvt('mean', {'axes', 'axis'}),
-    'ReduceProd'    : AttrCvt('prod', {'axes', 'axis'}),
+    'ReduceMax'     : AttrCvt('max', {'axes': 'axis'}),
+    'ReduceMin'     : AttrCvt('min', {'axes': 'axis'}),
+    'ReduceSum'     : AttrCvt('sum', {'axes': 'axis'}),
+    'ReduceMean'    : AttrCvt('mean', {'axes': 'axis'}),
+    'ReduceProd'    : AttrCvt('prod', {'axes': 'axis'}),
     # 'ReduceLogSumExp'
     # 'ArgMax'        : _arg_op('argmax'),
     # 'ArgMin'        : _arg_op('argmin'),

--- a/onnx_mxnet/tests/test_layers.py
+++ b/onnx_mxnet/tests/test_layers.py
@@ -14,6 +14,7 @@ import numpy as np
 import numpy.testing as npt
 from onnx import helper
 from onnx_mxnet import backend as mxnet_backend
+from unicodedata import decimal
 
 class TestLayers(unittest.TestCase):
     """Tests for different layers comparing output with numpy operators.
@@ -238,7 +239,7 @@ class TestLayers(unittest.TestCase):
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
         numpy_op = np.sum(ip1, axis=(1, 0), keepdims=True)
-        npt.assert_almost_equal(output, numpy_op)
+        npt.assert_almost_equal(output, numpy_op, decimal=5)
 
     def test_reduce_mean(self):
         """Test for ReduceMean operator"""
@@ -246,7 +247,7 @@ class TestLayers(unittest.TestCase):
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
         numpy_op = np.mean(ip1, axis=(1, 0), keepdims=True)
-        npt.assert_almost_equal(output, numpy_op)
+        npt.assert_almost_equal(output, numpy_op, decimal=5)
 
     def test_reduce_prod(self):
         """Test for ReduceProd operator"""
@@ -254,7 +255,7 @@ class TestLayers(unittest.TestCase):
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
         numpy_op = np.prod(ip1, axis=(1, 0), keepdims=True)
-        npt.assert_almost_equal(output, numpy_op)
+        npt.assert_almost_equal(output, numpy_op, decimal=5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/onnx_mxnet/tests/test_layers.py
+++ b/onnx_mxnet/tests/test_layers.py
@@ -215,6 +215,46 @@ class TestLayers(unittest.TestCase):
         exp_score = np.exp(ip1)
         numpy_op = exp_score / exp_score.sum(0)
         npt.assert_almost_equal(output, numpy_op)
+        
+    def test_reduceMax(self):
+        """Test for ReduceMax operator"""
+        node_def = helper.make_node("ReduceMax", ["ip1"], ["op1"], axes=1, keepdims=1)
+        ip1 = self._random_array([3, 10])
+        output = mxnet_backend.run_node(node_def, [ip1])[0]
+        numpy_op = np.max(ip1, axis=0, keepdims=True)
+        npt.assert_almost_equal(output, numpy_op)
+    
+    def test_reduceMin(self):
+        """Test for ReduceMin operator"""
+        node_def = helper.make_node("ReduceMin", ["ip1"], ["op1"], axes=[1], keepdims=1)
+        ip1 = self._random_array([3, 10])
+        output = mxnet_backend.run_node(node_def, [ip1])[0]
+        numpy_op = np.min(ip1, axis=0, keepdims=True)
+        npt.assert_almost_equal(output, numpy_op)
+    
+    def test_reduceSum(self):
+        """Test for ReduceSum operator"""
+        node_def = helper.make_node("ReduceSum", ["ip1"], ["op1"], axes=[1], keepdims=1)
+        ip1 = self._random_array([3, 10])
+        output = mxnet_backend.run_node(node_def, [ip1])[0]
+        numpy_op = np.sum(ip1, axis=0, keepdims=True)
+        #npt.assert_almost_equal(output, numpy_op)
+    
+    def test_reduceMean(self):
+        """Test for ReduceMean operator"""
+        node_def = helper.make_node("ReduceMean", ["ip1"], ["op1"], axes=[1], keepdims=1)
+        ip1 = self._random_array([3, 10])
+        output = mxnet_backend.run_node(node_def, [ip1])[0]
+        numpy_op = np.mean(ip1, axis=0, keepdims=True)
+        npt.assert_almost_equal(output, numpy_op)
+    
+    def test_reduceProd(self):
+        """Test for ReduceProd operator"""
+        node_def = helper.make_node("ReduceProd", ["ip1"], ["op1"], axes=[1], keepdims=1)
+        ip1 = self._random_array([3, 10])
+        output = mxnet_backend.run_node(node_def, [ip1])[0]
+        numpy_op = np.prod(ip1, axis=0, keepdims=True)
+        npt.assert_almost_equal(output, numpy_op)
 
 if __name__ == '__main__':
     unittest.main()

--- a/onnx_mxnet/tests/test_layers.py
+++ b/onnx_mxnet/tests/test_layers.py
@@ -218,42 +218,42 @@ class TestLayers(unittest.TestCase):
         
     def test_reduceMax(self):
         """Test for ReduceMax operator"""
-        node_def = helper.make_node("ReduceMax", ["ip1"], ["op1"], axes=1, keepdims=1)
+        node_def = helper.make_node("ReduceMax", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.max(ip1, axis=0, keepdims=True)
+        numpy_op = np.max(ip1, axis=(1,0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
     
     def test_reduceMin(self):
         """Test for ReduceMin operator"""
-        node_def = helper.make_node("ReduceMin", ["ip1"], ["op1"], axes=[1], keepdims=1)
+        node_def = helper.make_node("ReduceMin", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.min(ip1, axis=0, keepdims=True)
+        numpy_op = np.min(ip1, axis=(1,0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
     
     def test_reduceSum(self):
         """Test for ReduceSum operator"""
-        node_def = helper.make_node("ReduceSum", ["ip1"], ["op1"], axes=[1], keepdims=1)
+        node_def = helper.make_node("ReduceSum", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.sum(ip1, axis=0, keepdims=True)
-        #npt.assert_almost_equal(output, numpy_op)
+        numpy_op = np.sum(ip1, axis=(1,0), keepdims=True)
+        npt.assert_almost_equal(output, numpy_op)
     
     def test_reduceMean(self):
         """Test for ReduceMean operator"""
-        node_def = helper.make_node("ReduceMean", ["ip1"], ["op1"], axes=[1], keepdims=1)
+        node_def = helper.make_node("ReduceMean", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.mean(ip1, axis=0, keepdims=True)
+        numpy_op = np.mean(ip1, axis=(1,0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
     
     def test_reduceProd(self):
         """Test for ReduceProd operator"""
-        node_def = helper.make_node("ReduceProd", ["ip1"], ["op1"], axes=[1], keepdims=1)
+        node_def = helper.make_node("ReduceProd", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.prod(ip1, axis=0, keepdims=True)
+        numpy_op = np.prod(ip1, axis=(1,0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
 
 if __name__ == '__main__':

--- a/onnx_mxnet/tests/test_layers.py
+++ b/onnx_mxnet/tests/test_layers.py
@@ -215,45 +215,45 @@ class TestLayers(unittest.TestCase):
         exp_score = np.exp(ip1)
         numpy_op = exp_score / exp_score.sum(0)
         npt.assert_almost_equal(output, numpy_op)
-        
-    def test_reduceMax(self):
+
+    def test_reduce_max(self):
         """Test for ReduceMax operator"""
-        node_def = helper.make_node("ReduceMax", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
+        node_def = helper.make_node("ReduceMax", ["ip1"], ["op1"], axes=[1, 0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.max(ip1, axis=(1,0), keepdims=True)
+        numpy_op = np.max(ip1, axis=(1, 0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
-    
-    def test_reduceMin(self):
+
+    def test_reduce_min(self):
         """Test for ReduceMin operator"""
-        node_def = helper.make_node("ReduceMin", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
+        node_def = helper.make_node("ReduceMin", ["ip1"], ["op1"], axes=[1, 0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.min(ip1, axis=(1,0), keepdims=True)
+        numpy_op = np.min(ip1, axis=(1, 0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
-    
-    def test_reduceSum(self):
+
+    def test_reduce_sum(self):
         """Test for ReduceSum operator"""
-        node_def = helper.make_node("ReduceSum", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
+        node_def = helper.make_node("ReduceSum", ["ip1"], ["op1"], axes=[1, 0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.sum(ip1, axis=(1,0), keepdims=True)
+        numpy_op = np.sum(ip1, axis=(1, 0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
-    
-    def test_reduceMean(self):
+
+    def test_reduce_mean(self):
         """Test for ReduceMean operator"""
-        node_def = helper.make_node("ReduceMean", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
+        node_def = helper.make_node("ReduceMean", ["ip1"], ["op1"], axes=[1, 0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.mean(ip1, axis=(1,0), keepdims=True)
+        numpy_op = np.mean(ip1, axis=(1, 0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
-    
-    def test_reduceProd(self):
+
+    def test_reduce_prod(self):
         """Test for ReduceProd operator"""
-        node_def = helper.make_node("ReduceProd", ["ip1"], ["op1"], axes=[1,0], keepdims=1)
+        node_def = helper.make_node("ReduceProd", ["ip1"], ["op1"], axes=[1, 0], keepdims=1)
         ip1 = self._random_array([3, 10])
         output = mxnet_backend.run_node(node_def, [ip1])[0]
-        numpy_op = np.prod(ip1, axis=(1,0), keepdims=True)
+        numpy_op = np.prod(ip1, axis=(1, 0), keepdims=True)
         npt.assert_almost_equal(output, numpy_op)
 
 if __name__ == '__main__':

--- a/onnx_mxnet/tests/test_layers.py
+++ b/onnx_mxnet/tests/test_layers.py
@@ -14,7 +14,6 @@ import numpy as np
 import numpy.testing as npt
 from onnx import helper
 from onnx_mxnet import backend as mxnet_backend
-from unicodedata import decimal
 
 class TestLayers(unittest.TestCase):
     """Tests for different layers comparing output with numpy operators.


### PR DESCRIPTION
Models with reduce operators were not getting imported into mxnet, as described in this issue. This PR fixes that issue and has unit tests to cover those scenarios.