### PR TITLE
Fix the logic to handle broadcast for add and mul operators

### DIFF
--- a/onnx_mxnet/import_onnx.py
+++ b/onnx_mxnet/import_onnx.py
@@ -118,7 +118,7 @@ class GraphProto(object):
             # some workarounds for onnx problem
             mx_attr = self._fix_bias(new_op, mx_attr, len(inputs))
             mx_attr = self._fix_channels(new_op, mx_attr, list(node.input))
-            self._fix_bias_shape(node.op_type, graph.node[idx - 1].op_type, node.input, onnx_attr)
+            self._fix_bias_shape(node.op_type, node.input, onnx_attr)
 
             # calling again to get new symbols after some workarounds
             inputs = [self._nodes[self._renames.get(i, i)] for i in node.input]
@@ -292,7 +292,7 @@ class GraphProto(object):
         return attrs
 
 
-    def _fix_bias_shape(self, op_name, last_op_name, inputs, attrs):
+    def _fix_bias_shape(self, op_name, inputs, attrs):
         """A workaround to reshape bias term to (1, num_channel)."""
         if (op_name == 'Add' or op_name == 'Mul') and ('broadcast' in attrs and attrs['broadcast'] == 1L):
             assert len(list(inputs)) == 2

--- a/onnx_mxnet/import_onnx.py
+++ b/onnx_mxnet/import_onnx.py
@@ -118,7 +118,7 @@ class GraphProto(object):
             # some workarounds for onnx problem
             mx_attr = self._fix_bias(new_op, mx_attr, len(inputs))
             mx_attr = self._fix_channels(new_op, mx_attr, list(node.input))
-            self._fix_bias_shape(node.op_type, graph.node[idx - 1].op_type, node.input)
+            self._fix_bias_shape(node.op_type, graph.node[idx - 1].op_type, node.input, onnx_attr)
 
             # calling again to get new symbols after some workarounds
             inputs = [self._nodes[self._renames.get(i, i)] for i in node.input]
@@ -292,9 +292,9 @@ class GraphProto(object):
         return attrs
 
 
-    def _fix_bias_shape(self, op_name, last_op_name, inputs):
+    def _fix_bias_shape(self, op_name, last_op_name, inputs, attrs):
         """A workaround to reshape bias term to (1, num_channel)."""
-        if op_name == 'Add' and last_op_name == 'Conv' or op_name == 'Mul' or op_name == 'Add':
+        if (op_name == 'Add' or op_name == 'Mul') and ('broadcast' in attrs and attrs['broadcast'] == 1L):
             assert len(list(inputs)) == 2
             bias_name = self._renames.get(inputs[1], inputs[1])
             bias = self._params[bias_name]

--- a/onnx_mxnet/import_onnx.py
+++ b/onnx_mxnet/import_onnx.py
@@ -107,7 +107,7 @@ class GraphProto(object):
 
         # constructing nodes, nodes are stored as directed acyclic graph
         # converting NodeProto message
-        for idx, node in enumerate(graph.node):
+        for node in graph.node:
             op_name = node.op_type
             node_name = node.name.strip()
             node_name = node_name if node_name else None

--- a/onnx_mxnet/import_onnx.py
+++ b/onnx_mxnet/import_onnx.py
@@ -294,7 +294,8 @@ class GraphProto(object):
 
     def _fix_bias_shape(self, op_name, inputs, attrs):
         """A workaround to reshape bias term to (1, num_channel)."""
-        if (op_name == 'Add' or op_name == 'Mul') and ('broadcast' in attrs and attrs['broadcast'] == 1L):
+        if (op_name == 'Add' or op_name == 'Mul') and \
+                ('broadcast' in attrs and attrs['broadcast'] == 1):
             assert len(list(inputs)) == 2
             bias_name = self._renames.get(inputs[1], inputs[1])
             bias = self._params[bias_name]


### PR DESCRIPTION
Refactoring the logic to handle broadcast with Add and Mul operations.

ONNX handles bias in Conv like operators seperately i.e it keeps bias as False and then adds the bias to the conv result. The Add/Mul will  have "broadcast" attribute. 

(Existing logic was throwing error while importing custom resnet50 models , refer https://github.com/onnx/onnx-mxnet/issues/5)

Testing:
test_models.py passed.
test_layers.py passed


@Roshrini  @anirudhacharya @lupesko 