### PR TITLE
Refactoring run_node in backend.py.

### DIFF
--- a/onnx_mxnet/backend.py
+++ b/onnx_mxnet/backend.py
@@ -47,10 +47,10 @@ class MXNetBackend(Backend):
             if node.input[index] == 'W':
                 dim = inputs[index].shape
                 param_tensor = helper.make_tensor(
-                                   name=node.input[index],
-                                   data_type=TensorProto.FLOAT,
-                                   dims=dim,
-                                   vals=inputs[index].flatten())
+                    name=node.input[index],
+                    data_type=TensorProto.FLOAT,
+                    dims=dim,
+                    vals=inputs[index].flatten())
 
                 initializer.append(param_tensor)
 

--- a/onnx_mxnet/backend.py
+++ b/onnx_mxnet/backend.py
@@ -14,8 +14,10 @@
 from collections import namedtuple
 import mxnet as mx
 from onnx.backend.base import Backend
+from onnx import helper, TensorProto
 from .import_onnx import GraphProto
 from .backend_rep import MXNetBackendRep
+
 
 # Using these functions for onnx test infrastructure.
 # Implemented by following onnx docs guide:
@@ -25,6 +27,49 @@ from .backend_rep import MXNetBackendRep
 
 class MXNetBackend(Backend):
     """MXNet backend for ONNX"""
+
+    @staticmethod
+    def make_graph(node, inputs):
+        """ Created ONNX GraphProto from node"""
+        initializer = []
+        tensor_input_info = []
+        tensor_output_info = []
+
+        # Adding input tensor info.
+        for index in range(len(node.input)):
+            tensor_input_info.append(
+                helper.make_tensor_value_info(str(node.input[index]), TensorProto.FLOAT, [1]))
+
+            # Creating an initializer for Weight params.
+            # Assumes that weight params is named as 'W'.
+            # TODO: Handle multiple weight params.
+            # TODO: Add for "bias" if needed
+            if node.input[index] == 'W':
+                dim = inputs[index].shape
+                param_tensor = helper.make_tensor(
+                                   name=node.input[index],
+                                   data_type=TensorProto.FLOAT,
+                                   dims=dim,
+                                   vals=inputs[index].flatten())
+
+                initializer.append(param_tensor)
+
+        # Adding output tensor info.
+        for index in range(len(node.output)):
+            tensor_output_info.append(
+                helper.make_tensor_value_info(str(node.output[index]), TensorProto.FLOAT, [1]))
+
+        # creating graph proto object.
+        graph_proto = helper.make_graph(
+            [node],
+            "test",
+            tensor_input_info,
+            tensor_output_info,
+            initializer=initializer)
+
+        return graph_proto
+
+
     @classmethod
     def run_node(cls, node, inputs, device='CPU'):
         """Running individual node inference on mxnet engine and
@@ -45,12 +90,12 @@ class MXNetBackend(Backend):
             result obtained after running the operator
         """
         graph = GraphProto()
-        sym = graph.run_node(node)
-        data_names = [i for i in node.input]
+        sym, params = graph.from_onnx(MXNetBackend.make_graph(node, inputs))
+        data_names = [i for i in sym.get_internals().list_inputs() if i[:-1] == "input_"]
         data_shapes = []
         reduce_op_types = set(['ReduceMin', 'ReduceMax', 'ReduceMean',
                                'ReduceProd', 'ReduceSum', 'Slice', 'Pad',
-                               'Squeeze', 'Upsample', 'Reshape'])
+                               'Squeeze', 'Upsample', 'Reshape', 'Conv'])
 
         # Adding extra dimension of batch_size 1 if the batch_size is different for multiple inputs.
         for idx, input_name in enumerate(data_names):
@@ -74,15 +119,19 @@ class MXNetBackend(Backend):
         mod.bind(for_training=False, data_shapes=data_shapes, label_shapes=None)
 
         # initializing parameters for calculating result of each individual node
-        mod.init_params()
+        if int(len(params)) > 0:
+            mod.set_params(arg_params=params, aux_params=None)
+        else:
+            mod.init_params()
 
         batch = namedtuple('Batch', ['data'])
 
         data_forward = []
-        for val in inputs:
+        for idx, input_name in enumerate(data_names):
             # slice and pad operator tests needs 1 less dimension in forward pass
             # otherwise it will throw an error.
             # for squeeze operator, need to retain shape of input as provided
+            val = inputs[idx]
             if node.op_type in reduce_op_types:
                 data_forward.append(mx.nd.array(val))
             else:

--- a/onnx_mxnet/backend.py
+++ b/onnx_mxnet/backend.py
@@ -18,7 +18,6 @@ from onnx import helper, TensorProto
 from .import_onnx import GraphProto
 from .backend_rep import MXNetBackendRep
 
-
 # Using these functions for onnx test infrastructure.
 # Implemented by following onnx docs guide:
 # https://github.com/onnx/onnx/blob/master/docs/Implementing%20an%20ONNX%20backend.md
@@ -120,7 +119,7 @@ class MXNetBackend(Backend):
 
         # initializing parameters for calculating result of each individual node
         if int(len(params)) > 0:
-            mod.set_params(arg_params=params, aux_params=None)
+            mod.set_params(arg_params=params, aux_params=params)
         else:
             mod.init_params()
 

--- a/onnx_mxnet/import_helper.py
+++ b/onnx_mxnet/import_helper.py
@@ -108,7 +108,7 @@ def _activation(name):
             'alpha':'slope'},
         extras={'act_type': name})
 
-def _pad_sequence_fix(attr, kernelDim):
+def _pad_sequence_fix(attr, kernelDim=None):
     """Changing onnx's pads sequence to match with mxnet's pad_width
     mxnet: (x1_begin, x1_end, ... , xn_begin, xn_end)
     onnx: (x1_begin, x2_begin, ... , xn_end, xn_end)"""
@@ -117,8 +117,9 @@ def _pad_sequence_fix(attr, kernelDim):
         for index in range(int(len(attr) / 2)):
             new_attr = new_attr + attr[index::int(len(attr) / 2)]
         # Making sure pad values  are in the attr for all axes.
-        while len(new_attr) < kernelDim*2:
-            new_attr = new_attr + (0, 0)
+        if kernelDim is not None:
+            while len(new_attr) < kernelDim*2:
+                new_attr = new_attr + (0, 0)
 
     return new_attr
 

--- a/onnx_mxnet/tests/test_layers.py
+++ b/onnx_mxnet/tests/test_layers.py
@@ -278,5 +278,38 @@ class TestLayers(unittest.TestCase):
         output = mxnet_backend.run_node(node_def, [input1])[0]
         npt.assert_almost_equal(output, np.reshape(input1, [3, 2, 2, 2]))
 
+    def test_conv(self):
+        """ Test for Conv operator"""
+        # (1, 1, 5, 5) input tensor
+        x = np.array([[[[0., 1., 2., 3., 4.],
+                        [5., 6., 7., 8., 9.],
+                        [10., 11., 12., 13., 14.],
+                        [15., 16., 17., 18., 19.],
+                        [20., 21., 22., 23., 24.]]]]).astype(np.float32)
+        # (1, 1, 3, 3) tensor for convolution weights
+        W = np.array([[[[1., 1., 1.],
+                        [1., 1., 1.],
+                        [1., 1., 1.]]]]).astype(np.float32)
+        # (1, 1, 5, 5) output tenso
+        y_with_padding = np.array([[[[12., 21., 27., 33., 24.],
+                                     [33., 54., 63., 72., 51.],
+                                     [63., 99., 108., 117., 81.],
+                                     [93., 144., 153., 162., 111.],
+                                     [72., 111., 117., 123., 84.]]]]).astype(np.float32)
+
+        # Convolution with padding
+        # Default values for other attributes: strides=[1, 1], dilations=[1, 1], groups=1
+        node_with_padding = helper.make_node(
+            'Conv',
+            inputs=['x', 'W'],
+            outputs=['y'],
+            kernel_shape=[3, 3],
+            pads=[1, 1, 1, 1],
+        )
+
+        output = mxnet_backend.run_node(node_with_padding, [x, W])[0]
+        npt.assert_almost_equal(output, y_with_padding)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- create a graph from node
- call "from_onnx" to do the translation.
- Remove func "run_node" from import_onnx.py

Fixes conv tests in onnx backend tests.

With this change, ONNX backend test numbers are :  
Before: FAILED (failures=23, errors=49, skipped=372)
After :  FAILED (failures=23, errors=37, skipped=372)

@Roshrini  @anirudhacharya @nswamy @lupesko 