### PR TITLE
update readme to put emphasis to install the ONNX package before

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ With ONNX format support for MXNet, developers can build and train models with P
 
 ## Installation
 ### Prerequisite
-Install ONNX which needs protobuf compiler to be installed separately. Please follow the instructions to install ONNX [here](https://github.com/onnx/onnx).
+**Install ONNX** which needs protobuf compiler to be installed separately. Please **follow the instructions to install ONNX** [here](https://github.com/onnx/onnx).
 
-Then, you can install onnx-mxnet package as follows:
+**Then**, you can install onnx-mxnet package as follows:
 
 ```
 pip install onnx-mxnet


### PR DESCRIPTION
Update the readme to have more emphasis on installing ONNX before-hand. Caught me off-guard and the pip errors are all about gcc not being able to compile the package. Alternatively if we could have a more helpful error message in case someone forgets to install onnx that would be helpful.